### PR TITLE
Add PHP 8.1 support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -42,6 +42,7 @@ jobs:
         - "7.3"
         - "7.4"
         - "8.0"
+        - "8.1"
     steps:
     - uses: "actions/checkout@v2"
     - uses: "shivammathur/setup-php@v2"
@@ -64,6 +65,7 @@ jobs:
         - "7.3"
         - "7.4"
         - "8.0"
+        - "8.1"
     steps:
     - uses: "actions/checkout@v2"
     - uses: "shivammathur/setup-php@v2"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "~7.3.0 || ~7.4.0 || ~8.0.0",
+        "php": "~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
@@ -24,16 +24,20 @@
         "bin/phpcs-baseliner"
     ],
     "require-dev": {
-        "isaac/php-code-sniffer-standard": "^21.0",
+        "isaac/php-code-sniffer-standard": "^27.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan": "^0.12.65",
-        "phpstan/phpstan-phpunit": "^0.12.17",
-        "phpstan/phpstan-strict-rules": "^0.12.8",
+        "phpstan/phpstan": "^1.6.8",
+        "phpstan/phpstan-phpunit": "^1.1.1",
+        "phpstan/phpstan-strict-rules": "^1.2.3",
         "phpunit/phpunit": "^9.5"
     },
     "minimum-stability": "stable",
     "config": {
         "sort-packages": true,
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,7 +4,7 @@
   <file>tests</file>
   <exclude-pattern>/tests/Fixtures/</exclude-pattern>
   <rule ref="ISAAC"/>
-  <config name="php_version" value="70300-80100"/>
+  <config name="php_version" value="70300"/>
   <config name="testVersion" value="7.3-8.1"/>
   <arg name="extensions" value="php"/>
   <arg name="cache"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,7 +4,8 @@
   <file>tests</file>
   <exclude-pattern>/tests/Fixtures/</exclude-pattern>
   <rule ref="ISAAC"/>
-  <config name="testVersion" value="7.3-8.0"/>
+  <config name="php_version" value="70300-80100"/>
+  <config name="testVersion" value="7.3-8.1"/>
   <arg name="extensions" value="php"/>
   <arg name="cache"/>
 </ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,8 +2,8 @@ parameters:
     paths:
     - '.'
     level: 'max'
-    excludes_analyse:
-    - './vendor'
-    - './tests/Fixtures'
+    excludePaths:
+    - './vendor/*'
+    - './tests/Fixtures/*'
 includes:
 	- vendor/phpstan/phpstan/conf/bleedingEdge.neon

--- a/src/Baseline/Baseline.php
+++ b/src/Baseline/Baseline.php
@@ -7,12 +7,12 @@ namespace ISAAC\CodeSnifferBaseliner\Baseline;
 class Baseline
 {
     /**
-     * @var string[][][]
+     * @var array<array<array<string>>>
      */
     private $violatedRulesByFileAndLineNumber;
 
     /**
-     * @param string[][][] $violatedRulesByFileAndLineNumber
+     * @param array<array<array<string>>> $violatedRulesByFileAndLineNumber
      */
     public function __construct(array $violatedRulesByFileAndLineNumber)
     {
@@ -20,7 +20,7 @@ class Baseline
     }
 
     /**
-     * @return string[][][]
+     * @return array<array<array<string>>>
      */
     public function getViolatedRulesByFileAndLineNumber(): array
     {

--- a/src/Baseline/BaselineFactory.php
+++ b/src/Baseline/BaselineFactory.php
@@ -20,7 +20,7 @@ class BaselineFactory
     }
 
     /**
-     * @return string[][]
+     * @return array<array<string>>
      */
     private function groupSourcesByLine(FileReport $fileReport): array
     {

--- a/src/BaselineCreator.php
+++ b/src/BaselineCreator.php
@@ -95,7 +95,7 @@ class BaselineCreator
     }
 
     /**
-     * @param string[][] $ruleExclusionsByLineNumber
+     * @param array<array<string>> $ruleExclusionsByLineNumber
      */
     public function addRuleExclusionsByLineNumber(string $file, array $ruleExclusionsByLineNumber): bool
     {

--- a/src/PhpCodeSnifferRunner/Report/FileReport.php
+++ b/src/PhpCodeSnifferRunner/Report/FileReport.php
@@ -15,12 +15,12 @@ class FileReport
      */
     private $warningCount;
     /**
-     * @var Message[]
+     * @var array<Message>
      */
     private $messages;
 
     /**
-     * @param Message[] $messages
+     * @param array<Message> $messages
      */
     public function __construct(int $errorCount, int $warningCount, array $messages)
     {
@@ -40,7 +40,7 @@ class FileReport
     }
 
     /**
-     * @return Message[]
+     * @return array<Message>
      */
     public function getMessages(): array
     {

--- a/src/PhpCodeSnifferRunner/Report/Report.php
+++ b/src/PhpCodeSnifferRunner/Report/Report.php
@@ -11,12 +11,12 @@ class Report
      */
     private $totals;
     /**
-     * @var FileReport[]
+     * @var array<FileReport>
      */
     private $fileReportsByFilename;
 
     /**
-     * @param FileReport[] $fileReportsByFilename
+     * @param array<FileReport> $fileReportsByFilename
      */
     public function __construct(Totals $totals, array $fileReportsByFilename)
     {
@@ -30,7 +30,7 @@ class Report
     }
 
     /**
-     * @return FileReport[]
+     * @return array<FileReport>
      */
     public function getFileReportsByFilename(): array
     {

--- a/src/PhpCodeSnifferRunner/ReportDeserializer.php
+++ b/src/PhpCodeSnifferRunner/ReportDeserializer.php
@@ -43,7 +43,7 @@ class ReportDeserializer
     }
 
     /**
-     * @return FileReport[]
+     * @return array<FileReport>
      */
     private function denormalizeFileReports(object $normalizedFiles): array
     {
@@ -64,8 +64,8 @@ class ReportDeserializer
     }
 
     /**
-     * @param mixed[] $normalizedMessages
-     * @return Message[]
+     * @param array<mixed> $normalizedMessages
+     * @return array<Message>
      */
     private function denormalizeMessages(array $normalizedMessages): array
     {

--- a/src/PhpTokenizer/TokenizedSourceCode.php
+++ b/src/PhpTokenizer/TokenizedSourceCode.php
@@ -24,16 +24,16 @@ use const PHP_EOL;
 class TokenizedSourceCode implements IteratorAggregate
 {
     /**
-     * @var Token[][]
+     * @var array<array<Token>>
      */
     private $tokensByStartingLineNumber = [];
     /**
-     * @var array<int, Token[]>
+     * @var array<int, array<Token>>
      */
     private $tokensByEndingLineNumber = [];
 
     /**
-     * @param Token[] $tokens
+     * @param array<Token> $tokens
      */
     public function __construct(array $tokens)
     {

--- a/src/SourceCodeProcessor/AddBaselineProcessor.php
+++ b/src/SourceCodeProcessor/AddBaselineProcessor.php
@@ -12,6 +12,7 @@ use function array_splice;
 use function explode;
 use function implode;
 use function is_array;
+use function is_string;
 use function preg_match;
 use function preg_split;
 use function rtrim;
@@ -37,7 +38,7 @@ class AddBaselineProcessor
     }
 
     /**
-     * @param string[][] $ruleExclusionsByLineNumber
+     * @param array<array<string>> $ruleExclusionsByLineNumber
      */
     public function addRuleExclusionsByLineNumber(string $sourceCode, array $ruleExclusionsByLineNumber): string
     {
@@ -61,9 +62,9 @@ class AddBaselineProcessor
 
     /**
      * Inserts line(s) with comments to ignore specific rules.
-     * @param string[] $lines
-     * @param string[] $ruleExclusions
-     * @param int[] $lineNumbersAdded
+     * @param array<string> $lines
+     * @param array<string> $ruleExclusions
+     * @param array<int> $lineNumbersAdded
      */
     private function addRuleExclusions(
         array &$lines,
@@ -94,8 +95,8 @@ class AddBaselineProcessor
     }
 
     /**
-     * @param string[] $lines
-     * @param string[] $ruleExclusions
+     * @param array<string> $lines
+     * @param array<string> $ruleExclusions
      */
     private function ignoreInline(
         array &$lines,
@@ -137,9 +138,9 @@ class AddBaselineProcessor
     }
 
     /**
-     * @param string[] $lines
-     * @param string[] $ruleExclusions
-     * @param int[] $lineNumbersAdded
+     * @param array<string> $lines
+     * @param array<string> $ruleExclusions
+     * @param array<int> $lineNumbersAdded
      */
     private function insertEnableDisableComments(
         array &$lines,
@@ -164,8 +165,8 @@ class AddBaselineProcessor
     }
 
     /**
-     * @param string[] $lines
-     * @param int[] $lineNumbersAdded
+     * @param array<string> $lines
+     * @param array<int> $lineNumbersAdded
      */
     private function insertOrMergeComment(
         array &$lines,
@@ -195,7 +196,7 @@ class AddBaselineProcessor
     private function determineIndentation(string $line): string
     {
         preg_match('`^(?<indent>\\s*)[^\\s]`', $line, $matches);
-        if (!is_array($matches) || !array_key_exists('indent', $matches)) {
+        if (!is_array($matches) || !array_key_exists('indent', $matches) || !is_string($matches['indent'])) {
             return '';
         }
         return $matches['indent'];
@@ -219,7 +220,7 @@ class AddBaselineProcessor
     }
 
     /**
-     * @param int[] $lineNumbersAdded
+     * @param array<int> $lineNumbersAdded
      */
     private function getActualLineNumber(int $originalLineNumber, array $lineNumbersAdded): int
     {

--- a/src/SourceCodeProcessor/InstructionComment.php
+++ b/src/SourceCodeProcessor/InstructionComment.php
@@ -28,17 +28,17 @@ class InstructionComment
      */
     private $instruction;
     /**
-     * @var string[]
+     * @var array<string>
      */
     private $rules;
     /**
-     * @var string[]
+     * @var array<string>
      */
     private $messages;
 
     /**
-     * @param string[] $rules
-     * @param string[] $messages
+     * @param array<string> $rules
+     * @param array<string> $messages
      */
     public function __construct(
         string $instruction,

--- a/src/SourceCodeProcessor/InstructionCommentLineParser.php
+++ b/src/SourceCodeProcessor/InstructionCommentLineParser.php
@@ -45,7 +45,7 @@ class InstructionCommentLineParser
 
     /**
      * @param string $commaSeparatedRules
-     * @return string[]
+     * @return array<string>
      */
     private function parseRules(string $commaSeparatedRules): array
     {
@@ -62,7 +62,7 @@ class InstructionCommentLineParser
 
     /**
      * @param string $semiColonSeparatedMessages
-     * @return string[]
+     * @return array<string>
      */
     private function parseMessages(string $semiColonSeparatedMessages): array
     {

--- a/src/Util/PropertyAccessor.php
+++ b/src/Util/PropertyAccessor.php
@@ -46,7 +46,7 @@ class PropertyAccessor
     }
 
     /**
-     * @return mixed[]
+     * @return array<mixed>
      */
     public static function getArrayProperty(object $object, string $propertyName, string $objectName): array
     {

--- a/tests/Filesystem/MemoryFilesystem.php
+++ b/tests/Filesystem/MemoryFilesystem.php
@@ -9,7 +9,7 @@ use ISAAC\CodeSnifferBaseliner\Filesystem\Filesystem;
 class MemoryFilesystem implements Filesystem
 {
     /**
-     * @var string[]
+     * @var array<string>
      */
     private $fileContentsByFilename = [];
 

--- a/tests/Fixtures/composer.json
+++ b/tests/Fixtures/composer.json
@@ -1,5 +1,16 @@
 {
   "require": {
-    "isaac/php-code-sniffer-standard": "^22.0"
+    "isaac/php-code-sniffer-standard": "*"
+  },
+  "repositories": {
+    "isaac/php-code-sniffer-standard": {
+      "type": "path",
+      "url": "../../"
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/tests/Fixtures/phpcs.xml
+++ b/tests/Fixtures/phpcs.xml
@@ -2,4 +2,6 @@
 <ruleset>
   <file>src</file>
   <rule ref="ISAAC"/>
+  <config name="php_version" value="70300-80100"/>
+  <config name="testVersion" value="7.3-8.1"/>
 </ruleset>

--- a/tests/Fixtures/phpcs.xml
+++ b/tests/Fixtures/phpcs.xml
@@ -2,6 +2,6 @@
 <ruleset>
   <file>src</file>
   <rule ref="ISAAC"/>
-  <config name="php_version" value="70300-80100"/>
+  <config name="php_version" value="70300"/>
   <config name="testVersion" value="7.3-8.1"/>
 </ruleset>

--- a/tests/PhpCodeSnifferRunner/Report/FileReportFactory.php
+++ b/tests/PhpCodeSnifferRunner/Report/FileReportFactory.php
@@ -13,7 +13,7 @@ use function count;
 class FileReportFactory
 {
     /**
-     * @param Message[] $messagesOrDefault
+     * @param array<Message>|null $messagesOrDefault
      */
     public static function create(
         ?int $errorCount = null,
@@ -37,7 +37,7 @@ class FileReportFactory
     }
 
     /**
-     * @param Message[] $messages
+     * @param ?array<Message> $messages
      */
     public static function createWithMessages(?array $messages = null): FileReport
     {

--- a/tests/PhpCodeSnifferRunner/Report/FileReportFactory.php
+++ b/tests/PhpCodeSnifferRunner/Report/FileReportFactory.php
@@ -37,7 +37,7 @@ class FileReportFactory
     }
 
     /**
-     * @param ?array<Message> $messages
+     * @param array<Message>|null $messages
      */
     public static function createWithMessages(?array $messages = null): FileReport
     {

--- a/tests/PhpCodeSnifferRunner/Report/ReportFactory.php
+++ b/tests/PhpCodeSnifferRunner/Report/ReportFactory.php
@@ -14,7 +14,7 @@ use function array_sum;
 class ReportFactory
 {
     /**
-     * @param FileReport[] $fileReportsByFilenameOrDefault
+     * @param array<FileReport>|null $fileReportsByFilenameOrDefault
      */
     public static function create(
         ?Totals $totals = null,
@@ -35,7 +35,7 @@ class ReportFactory
     }
 
     /**
-     * @param FileReport[] $fileReportsByFilename
+     * @param array<FileReport> $fileReportsByFilename
      */
     public static function createWithFileReportsByFilename(array $fileReportsByFilename): Report
     {

--- a/tests/SourceCodeProcessor/AddBaselineProcessorTest.php
+++ b/tests/SourceCodeProcessor/AddBaselineProcessorTest.php
@@ -22,7 +22,7 @@ class AddBaselineProcessorTest extends TestCase
     }
 
     /**
-     * @param string[][] $ruleExclusionsByLineNumber
+     * @param array<array<string>> $ruleExclusionsByLineNumber
      * @dataProvider \ISAAC\CodeSnifferBaseliner\Tests\SourceCodeProcessor\AddBaselineProcessorTestDataProvider::provide
      */
     public function testAddRuleExclusionsByLineNumber(

--- a/tests/SourceCodeProcessor/AddBaselineProcessorTestDataProvider.php
+++ b/tests/SourceCodeProcessor/AddBaselineProcessorTestDataProvider.php
@@ -728,7 +728,7 @@ PHP
     ];
 
     /**
-     * @return mixed[]
+     * @return array<mixed>
      */
     public static function provide(): array
     {


### PR DESCRIPTION
- Update ISAAC Codesniffer Standard version to 27
- Update PHPStan versions to support PHP 8.1
- Fix CS issues caused by updating phpcs and phpstan