### PR TITLE
Fix totals parsing in ReportDeserializer

### DIFF
--- a/src/PhpCodeSnifferRunner/ReportDeserializer.php
+++ b/src/PhpCodeSnifferRunner/ReportDeserializer.php
@@ -37,8 +37,8 @@ class ReportDeserializer
     {
         return new Totals(
             PropertyAccessor::getIntegerProperty($normalizedTotals, 'errors', 'totals'),
-            PropertyAccessor::getIntegerProperty($normalizedTotals, 'errors', 'totals'),
-            PropertyAccessor::getIntegerProperty($normalizedTotals, 'errors', 'totals')
+            PropertyAccessor::getIntegerProperty($normalizedTotals, 'warnings', 'totals'),
+            PropertyAccessor::getIntegerProperty($normalizedTotals, 'fixable', 'totals')
         );
     }
 


### PR DESCRIPTION
When `phpcs` reports only warnings but no errors, `phpcs-baseliner create-baseline` fails with `PHP_CodeSniffer did not report any errors.` and does not create any ignore comments for the warnings.

This seems to be caused by the `ReportDeserializer` which does not distinguish between errors and warnings. This PR adds the missing distinction.